### PR TITLE
Force install in "lib"

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -35,6 +35,7 @@ class DoubleConversionConan(ConanFile):
 
     def configure_cmake(self):
         cmake = CMake(self)
+        cmake.definitions["CMAKE_INSTALL_LIBDIR"] = "lib"
         cmake.definitions["BUILD_TESTING"] = False # example
         if self.settings.os != 'Windows':
             cmake.definitions['CMAKE_POSITION_INDEPENDENT_CODE'] = self.options.fPIC


### PR DESCRIPTION
On some systems CMake will install libraries in "lib64" instead of
"lib", which causes problems when consuming the package. This change
forces the installation into "lib".